### PR TITLE
Fix compatiblility with OCaml 4.10.0beta2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - PACKAGE="grenier"
     - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
   matrix:
-    - DISTRO=debian-stable OCAML_VERSION=4.03.0
     - DISTRO=debian-unstable OCAML_VERSION=4.09.0
     - DISTRO=alpine OCAML_VERSION=4.04.0
     - DISTRO=alpine OCAML_VERSION=4.05.0

--- a/grenier.opam
+++ b/grenier.opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.04"}
   "dune" {>= "1.2.0"}
 ]
 synopsis: "A collection of various algorithms in OCaml"

--- a/physh/ml_physh_map.c
+++ b/physh/ml_physh_map.c
@@ -13,11 +13,6 @@
 CAMLextern void caml_minor_collection (void);
 #endif
 
-#if OCAML_VERSION < 40400
-#define Is_young(val) \
-  ((void*)(val) < (void*)caml_young_end && (void*)(val) > (void*)caml_young_start)
-#endif
-
 static int value_is_young(value obj)
 {
   return (Is_block(obj) && Is_young(obj));

--- a/physh/ml_physh_map.c
+++ b/physh/ml_physh_map.c
@@ -7,19 +7,10 @@
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
 #include <caml/fail.h>
+#include <caml/gc_ctrl.h>
 
 #if OCAML_VERSION < 41000
 CAMLextern void caml_minor_collection (void);
-
-extern value *caml_young_ptr, *caml_young_start, *caml_young_end;
-
-extern intnat
-     caml_stat_minor_collections,
-     caml_stat_major_collections,
-     caml_stat_heap_wsz,
-     caml_stat_top_heap_wsz,
-     caml_stat_compactions,
-     caml_stat_heap_chunks;
 #endif
 
 #if OCAML_VERSION < 40400

--- a/physh/ml_physh_set.c
+++ b/physh/ml_physh_set.c
@@ -12,11 +12,6 @@
 CAMLextern void caml_minor_collection (void);
 #endif
 
-#if OCAML_VERSION < 40400
-#define Is_young(val) \
-  ((void*)(val) < (void*)caml_young_end && (void*)(val) > (void*)caml_young_start)
-#endif
-
 static int value_is_young(value obj)
 {
   return (Is_block(obj) && Is_young(obj));

--- a/physh/ml_physh_set.c
+++ b/physh/ml_physh_set.c
@@ -6,19 +6,10 @@
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/gc_ctrl.h>
 
 #if OCAML_VERSION < 41000
 CAMLextern void caml_minor_collection (void);
-
-extern value *caml_young_ptr, *caml_young_start, *caml_young_end;
-
-extern intnat
-     caml_stat_minor_collections,
-     caml_stat_major_collections,
-     caml_stat_heap_wsz,
-     caml_stat_top_heap_wsz,
-     caml_stat_compactions,
-     caml_stat_heap_chunks;
 #endif
 
 #if OCAML_VERSION < 40400


### PR DESCRIPTION
After a lot of discussions ocaml/ocaml#9253 has finally been chosen to fix the compatibility issue in the next version of the OCaml compiler, however currently the grenier is not compatible with OCaml 4.10 anymore. This PR fixes the issue.