### PR TITLE
Update to OCaml 5.1

### DIFF
--- a/balmap/map.ml
+++ b/balmap/map.ml
@@ -368,4 +368,11 @@ struct
 
   let of_seq seq =
     add_seq seq empty
+
+  let add_to_list x data m =
+    let add = function None -> Some [data] | Some l -> Some (data :: l) in
+    update x add m
+
+  let to_list = bindings
+  let of_list bs = List.fold_left (fun m (k, v) -> add k v m) empty bs
 end

--- a/balmap/set.ml
+++ b/balmap/set.ml
@@ -366,4 +366,6 @@ struct
         Bt1.node l k1 r
       else
         Bt1.join l r
+
+  let to_list = elements
 end

--- a/physh/ml_physh_map.c
+++ b/physh/ml_physh_map.c
@@ -13,6 +13,12 @@
 CAMLextern void caml_minor_collection (void);
 #endif
 
+#if OCAML_VERSION < 50100
+#define get_minor_collections() caml_stat_minor_collections
+#else
+#define get_minor_collections() atomic_load(&caml_minor_collections_count)
+#endif
+
 static int value_is_young(value obj)
 {
   return (Is_block(obj) && Is_young(obj));
@@ -61,7 +67,7 @@ value ml_physh_map_alloc(value empty, value null)
   Field(vmin, 3) = null;
 
   v = caml_alloc_small(6, 0);
-  Field(v, 0) = Val_int(caml_stat_minor_collections);
+  Field(v, 0) = Val_int(get_minor_collections());
   Field(v, 1) = Val_int(0);
   Field(v, 2) = vmin;
   Field(v, 3) = Val_int(caml_stat_compactions);
@@ -82,12 +88,12 @@ static int has_capacity(size_t sz, size_t n)
 
 static int t_minor_is_valid(value t)
 {
-  return (Int_val(Field(t, 0)) == caml_stat_minor_collections);
+  return (Int_val(Field(t, 0)) == get_minor_collections());
 }
 
 static void t_minor_set_valid(value t)
 {
-  Field(t, 0) = Val_int(caml_stat_minor_collections);
+  Field(t, 0) = Val_int(get_minor_collections());
 }
 
 static size_t t_minor_fill(value t)


### PR DESCRIPTION
lrgrep currently depends on cmon, which in turn depends on grenier. Dun to #8, it's not currently possible to any of these packages on OCaml 5.1.

This replaces the use of `caml_stat_minor_collections` with `atomic_load(&caml_minor_collections_count)` when running on OCaml 5.1 or later. It's not entirely clear to me whether this module is correct in the presence of multiple domains - a possible alternative would just be to disable this whole module on OCaml 5.1+, if that would be preferred?