### PR TITLE
Add support for OCaml 5.5

### DIFF
--- a/balmap/map.ml
+++ b/balmap/map.ml
@@ -25,6 +25,7 @@ struct
   let empty = Bt2.leaf
 
   let is_empty = function Leaf -> true | Node _ -> false
+  let is_singleton = function Node (_, Leaf, _, _, Leaf) -> true | Leaf | Node _ -> false
 
   let rec mem k = function
     | Leaf -> false

--- a/balmap/set.ml
+++ b/balmap/set.ml
@@ -22,6 +22,7 @@ struct
   let empty = Bt1.leaf
 
   let is_empty = function Leaf -> true | Node _ -> false
+  let is_singleton = function Node (_, Leaf, _, Leaf) -> true | Leaf | Node _ -> false
 
   let rec mem k = function
     | Leaf -> false


### PR DESCRIPTION
```
#=== ERROR while compiling grenier.0.15 =======================================#
# context              2.5.0 | linux/x86_64 | ocaml-variants.5.5.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/grenier.0.15
# command              ~/.opam/5.5/bin/dune build -p grenier -j 1
# exit-code            1
# env-file             ~/.opam/log/grenier-13-f1182d.env
# output-file          ~/.opam/log/grenier-13-f1182d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I balmap/.balmap.objs/byte -I baltree/.grenier_baltree.objs/byte -no-alias-deps -open Balmap -o balmap/.balmap.objs/byte/balmap__Map.cmo -c -impl balmap/map.ml)
# File "balmap/map.ml", lines 12-385, characters 0-3:
#  12 | struct
#  13 |   type key = O.t
#  14 | 
#  15 |   type 'a t = (O.t, 'a) balmap
#  16 | 
# ...
# 382 | 
# 383 |   let to_list = bindings
# 384 |   let of_list bs = List.fold_left (fun m (k, v) -> add k v m) empty bs
# 385 | end
# Error: Signature mismatch:
#        ...
#        The value is_singleton is required but not provided
#        File "map.mli", line 307, characters 4-34: Expected declaration
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I balmap/.balmap.objs/byte -I baltree/.grenier_baltree.objs/byte -no-alias-deps -open Balmap -o balmap/.balmap.objs/byte/balmap__Set.cmo -c -impl balmap/set.ml)
# File "balmap/set.ml", lines 11-371, characters 0-3:
#  11 | struct
#  12 |   type elt = O.t
#  13 | 
#  14 |   type t = O.t balset
#  15 | 
# ...
# 368 |         Bt1.join l r
# 369 | 
# 370 |   let to_list = elements
# 371 | end
# Error: Signature mismatch:
#        ...
#        The value is_singleton is required but not provided
#        File "set.mli", line 263, characters 4-31: Expected declaration
```